### PR TITLE
Update `hasTaskDecorator` helper to include CallExpression as a valid expression Type

### DIFF
--- a/rules/no-native-promise-helpers.test.js
+++ b/rules/no-native-promise-helpers.test.js
@@ -330,5 +330,26 @@ export default class extends Component {
         },
       ],
     },
+    {
+      code: `
+        export default class extends Component {
+          @task({ maxConcurrency: 3, }) *submitTask() {
+            yield Promise.all([
+              this.saveTask.perform(),
+              this.loadingSpinnerTask.perform(),
+            ]);
+          }
+        }
+      `,
+      errors: [
+        {
+          message: "Use `import { all } from 'ember-concurrency';` instead of `Promise.all()`",
+          line: 4,
+          column: 19,
+          endLine: 7,
+          endColumn: 15,
+        },
+      ],
+    },
   ],
 });

--- a/rules/require-task-name-suffix.test.js
+++ b/rules/require-task-name-suffix.test.js
@@ -72,6 +72,10 @@ let INVALID_BABEL = [
     code: `export default class extends Component { @enqueueTask *submit() { } }`,
     errors: [{ message: 'Task names should end with `Task`', column: 56 }],
   },
+  {
+    code: `export default class extends Component { @task({ maxConcurrency: 3, }) *submit() { } }`,
+    errors: [{ message: 'Task names should end with `Task`', column: 73 }],
+  },
 ];
 
 let ruleTester = new RuleTester({

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -9,6 +9,13 @@ function hasTaskDecorator(node) {
 
   return node.decorators.some(decorator => {
     let { expression } = decorator;
-    return expression && expression.type === 'Identifier' && TASK_TYPES.includes(expression.name);
+    if (!expression) return false;
+    if (expression.type === 'Identifier' && TASK_TYPES.includes(expression.name)) return true;
+    return (
+      expression.type === 'CallExpression' &&
+      expression.callee &&
+      expression.callee.type === 'Identifier' &&
+      TASK_TYPES.includes(expression.callee.name)
+    );
   });
 }


### PR DESCRIPTION
This is a bug fix for the `hasTaskDecorator` which failed to recognise task decorators that had arguments passed in.

e.g. the `({ maxConcurrency: 3 })` section of the below code snippet.

```js
  export default class extends Component {
    @task({ maxConcurrency: 3, }) *submitTask() {
      yield Promise.all([
        this.saveTask.perform(),
        this.loadingSpinnerTask.perform(),
      ]);
    }
  }
```