### PR TITLE
Adding the `no-debug` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,6 @@ module.exports = {
     'no-native-promise-helpers': require('./rules/no-native-promise-helpers'),
     'no-perform-without-catch': require('./rules/no-perform-without-catch'),
     'require-task-name-suffix': require('./rules/require-task-name-suffix'),
+    'no-debug': require('./rules/no-debug'),
   },
 };

--- a/rules/no-debug.js
+++ b/rules/no-debug.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const { hasTaskDecorator } = require('../utils/utils');
+
+module.exports = {
+  create(context) {
+    return {
+      Property(node) {
+        if (node.method || node.shorthand || node.computed) return;
+        let { key, value } = node;
+        if (hasTaskCallExpression(value) && hasDebugCallee(value)) {
+          context.report({
+            node: key,
+            message: 'Unexpected task debugger',
+          });
+        }
+      },
+      MethodDefinition(node) {
+        let { key, value, decorators } = node;
+        if (!decorators) return;
+        if (!value) return;
+        if (!value.generator) return;
+        if (hasTaskDecorator(node) && hasDebugArgument(node)) {
+          context.report({
+            node: key,
+            message: 'Unexpected task debugger',
+          });
+        }
+      },
+      ClassProperty(node) {
+        if (node.static || node.computed) return;
+
+        let { key, value, decorators } = node;
+        if (value !== null) return;
+        if (!decorators) return;
+
+        for (let decorator of node.decorators) {
+          if (hasTaskCallExpression(decorator.expression) && hasDebugCallee(decorator.expression)) {
+            context.report({
+              node: key,
+              message: 'Unexpected task debugger',
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+function hasTaskCallExpression(node) {
+  return Boolean(findTaskCallExpression(node));
+}
+
+function findTaskCallExpression(node) {
+  if (isTaskCallExpression(node)) {
+    return node;
+  }
+
+  if (node.type === 'CallExpression' && node.callee.type === 'MemberExpression') {
+    return findTaskCallExpression(node.callee.object);
+  }
+}
+
+function isTaskCallExpression(node) {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'Identifier' &&
+    node.callee.name === 'task' &&
+    node.arguments[0] &&
+    node.arguments[0].type === 'FunctionExpression' &&
+    node.arguments[0].generator
+  );
+}
+
+function hasDebugCallee(node) {
+  let { callee } = node;
+  return (
+    callee.type === 'MemberExpression' &&
+    callee.property &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'debug'
+  );
+}
+
+function hasDebugArgument(node) {
+  if (!node.decorators) return false;
+
+  return node.decorators.some(decorator => {
+    let { expression } = decorator;
+
+    if (!expression) return false;
+    if (!expression.arguments) return false;
+
+    return expression.arguments.some(argument => {
+      if (argument.type !== 'ObjectExpression') return false;
+
+      return argument.properties.some(property => {
+        return property.key && property.key.name === 'debug';
+      });
+    });
+  });
+}

--- a/rules/no-debug.md
+++ b/rules/no-debug.md
@@ -1,0 +1,58 @@
+# no-debug
+
+This rule ensures that all `ember-concurrency` tasks in the app
+do not have debug shipped into production.
+
+
+## Examples
+
+This rule **forbids** the following:
+
+```js
+export default Component.extend({
+  submit: task(function*() {
+    //...
+  }).debug(),
+})
+```
+
+```js
+export default class extends Component {
+  @(task(function*() {
+    //...
+  }).debug()) submitTask;
+}
+```
+
+```js
+export default class extends Component {
+  @task({ debug: true }) *submitTask() {
+    //...
+  }
+}
+
+```
+
+This rule **allows** the following:
+
+```js
+export default class extends Component {
+  @task *submitTask() { };
+}
+```
+
+```js
+export default Component.extend({
+  submit: task(function*() {
+    //...
+  }).debug(),
+})
+```
+
+```js
+export default class extends Component {
+  @(task(function*() {
+    //...
+  }).debug()) submitTask;
+}
+```

--- a/rules/no-debug.test.js
+++ b/rules/no-debug.test.js
@@ -1,0 +1,78 @@
+const { RuleTester } = require('eslint');
+
+const rule = require('./no-debug');
+
+let VALID = [`export default Component.extend({ submitTask: task(function*() {}) });`];
+
+let INVALID = [
+  {
+    code: `export default Component.extend({ submitTask: task(function*() {}).debug() });`,
+    errors: [{ message: 'Unexpected task debugger', column: 35 }],
+  },
+];
+
+let VALID_BABEL = [
+  `export default class extends Component { @task *submitTask() { }; }`,
+  `export default class extends Component { @restartableTask *submitTask() { }; }`,
+  `export default class extends Component { @dropTask *submitTask() { }; }`,
+  `export default class extends Component { @keepLatestTask *submitTask() { }; }`,
+  `export default class extends Component { @enqueueTask *submitTask() { }; }`,
+  `export default class extends Component { @task(function*() {}) submitTask; }`,
+  `export default class extends Component { @(task(function*() {})) submitTask; }`,
+];
+
+let INVALID_BABEL = [
+  {
+    code: `export default class extends Component { @(task(function*() {}).debug()) submitTask; }`,
+    errors: [{ message: 'Unexpected task debugger', column: 74 }],
+  },
+  {
+    code: `export default class extends Component { @(task(function*() {}).debug()) submitTask; }`,
+    errors: [{ message: 'Unexpected task debugger', column: 74 }],
+  },
+  {
+    code: `export default class extends Component { @task({ debug: true }) *submitTask() { } }`,
+    errors: [{ message: 'Unexpected task debugger', column: 66 }],
+  },
+  {
+    code: `export default class extends Component { @restartableTask({ debug: true }) *submitTask() { } }`,
+    errors: [{ message: 'Unexpected task debugger', column: 77 }],
+  },
+  {
+    code: `export default class extends Component { @dropTask({ debug: true }) *submitTask() { } }`,
+    errors: [{ message: 'Unexpected task debugger', column: 70 }],
+  },
+  {
+    code: `export default class extends Component { @keepLatestTask({ debug: true }) *submitTask() { } }`,
+    errors: [{ message: 'Unexpected task debugger', column: 76 }],
+  },
+  {
+    code: `export default class extends Component { @enqueueTask({ debug: true }) *submitTask() { } }`,
+    errors: [{ message: 'Unexpected task debugger', column: 73 }],
+  },
+];
+
+let ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-debug', rule, {
+  valid: VALID,
+  invalid: INVALID,
+});
+
+let babelRuleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+});
+
+babelRuleTester.run('no-debug', rule, {
+  valid: [...VALID, ...VALID_BABEL],
+  invalid: [...INVALID, ...INVALID_BABEL],
+});


### PR DESCRIPTION
This PR adds the `no-debug` rule to help users avoid shipping them in production code. This is the implementation for issue #5 