### PR TITLE
Move `hasTaskCallExpression` to utils

### DIFF
--- a/rules/no-debug.js
+++ b/rules/no-debug.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { hasTaskDecorator } = require('../utils/utils');
+const { hasTaskDecorator, hasTaskCallExpression } = require('../utils/utils');
 
 module.exports = {
   create(context) {
@@ -46,31 +46,6 @@ module.exports = {
     };
   },
 };
-
-function hasTaskCallExpression(node) {
-  return Boolean(findTaskCallExpression(node));
-}
-
-function findTaskCallExpression(node) {
-  if (isTaskCallExpression(node)) {
-    return node;
-  }
-
-  if (node.type === 'CallExpression' && node.callee.type === 'MemberExpression') {
-    return findTaskCallExpression(node.callee.object);
-  }
-}
-
-function isTaskCallExpression(node) {
-  return (
-    node.type === 'CallExpression' &&
-    node.callee.type === 'Identifier' &&
-    node.callee.name === 'task' &&
-    node.arguments[0] &&
-    node.arguments[0].type === 'FunctionExpression' &&
-    node.arguments[0].generator
-  );
-}
 
 function hasDebugCallee(node) {
   let { callee } = node;

--- a/rules/require-task-name-suffix.js
+++ b/rules/require-task-name-suffix.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { hasTaskDecorator } = require('../utils/utils');
+const { hasTaskDecorator, hasTaskCallExpression } = require('../utils/utils');
 
 module.exports = {
   create(context) {
@@ -52,28 +52,3 @@ module.exports = {
     };
   },
 };
-
-function hasTaskCallExpression(node) {
-  return Boolean(findTaskCallExpression(node));
-}
-
-function findTaskCallExpression(node) {
-  if (isTaskCallExpression(node)) {
-    return node;
-  }
-
-  if (node.type === 'CallExpression' && node.callee.type === 'MemberExpression') {
-    return findTaskCallExpression(node.callee.object);
-  }
-}
-
-function isTaskCallExpression(node) {
-  return (
-    node.type === 'CallExpression' &&
-    node.callee.type === 'Identifier' &&
-    node.callee.name === 'task' &&
-    node.arguments[0] &&
-    node.arguments[0].type === 'FunctionExpression' &&
-    node.arguments[0].generator
-  );
-}

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -2,7 +2,7 @@
 
 const TASK_TYPES = ['task', 'restartableTask', 'dropTask', 'keepLatestTask', 'enqueueTask'];
 
-module.exports = { hasTaskDecorator };
+module.exports = { hasTaskDecorator, hasTaskCallExpression };
 
 function hasTaskDecorator(node) {
   if (!node.decorators) return false;
@@ -18,4 +18,29 @@ function hasTaskDecorator(node) {
       TASK_TYPES.includes(expression.callee.name)
     );
   });
+}
+
+function hasTaskCallExpression(node) {
+  return Boolean(findTaskCallExpression(node));
+}
+
+function findTaskCallExpression(node) {
+  if (isTaskCallExpression(node)) {
+    return node;
+  }
+
+  if (node.type === 'CallExpression' && node.callee.type === 'MemberExpression') {
+    return findTaskCallExpression(node.callee.object);
+  }
+}
+
+function isTaskCallExpression(node) {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'Identifier' &&
+    node.callee.name === 'task' &&
+    node.arguments[0] &&
+    node.arguments[0].type === 'FunctionExpression' &&
+    node.arguments[0].generator
+  );
 }


### PR DESCRIPTION
As it is likely that `hasTaskCallExpression` will be needed in further rules in the future i have move it to the utils file to tidy up the rule definitions 